### PR TITLE
Turn dry-run into a real flag

### DIFF
--- a/cmd/pets/cmd.go
+++ b/cmd/pets/cmd.go
@@ -2,16 +2,19 @@ package pets
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
+
+var dryRun bool
 
 // func main() {
 // 	Execute()
 // }
 
 func init() {
-	RootCmd.AddCommand(DryRunCmd)
+	RootCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "just print recommended commands, don't run them")
 }
 
 var RootCmd = &cobra.Command{
@@ -20,9 +23,15 @@ var RootCmd = &cobra.Command{
 	Long: `A PETS file is like a Makefile for running servers and connecting them 
 	to other servers. With PETS, we can switch back and forth quickly
 	between servers running locally and servers running in the cloud.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("You ran pets!")
-	},
+	Run: pets,
+}
+
+func pets(cmd *cobra.Command, args []string) {
+	if dryRun {
+		fmt.Fprintln(os.Stderr, "pets dry-run")
+	} else {
+		fmt.Fprintln(os.Stderr, "You ran pets!")
+	}
 }
 
 // func Execute() {

--- a/cmd/pets/cmd.go
+++ b/cmd/pets/cmd.go
@@ -14,7 +14,7 @@ var dryRun bool
 // }
 
 func init() {
-	RootCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "just print recommended commands, don't run them")
+	RootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "just print recommended commands, don't run them")
 }
 
 var RootCmd = &cobra.Command{


### PR DESCRIPTION
More sophisticated use of dry-run, extended the cmd.go file so that the function isn't just hidden inside RootCmd