### PR TITLE
mill: Add Petsfile hook for go-get

### DIFF
--- a/internal/mill/exec.go
+++ b/internal/mill/exec.go
@@ -2,13 +2,19 @@ package mill
 
 import (
 	"fmt"
+	"go/build"
 	"io"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/google/skylark"
+	"github.com/windmilleng/pets/internal/loader"
 	"github.com/windmilleng/pets/internal/proc"
 )
+
+const Petsfile = "Petsfile"
 
 type Petsitter struct {
 	Stdout io.Writer
@@ -19,7 +25,10 @@ type Petsitter struct {
 // ExecFile takes a Petsfile and parses it using the Skylark interpreter
 func (p *Petsitter) ExecFile(file string) error {
 	thread := &skylark.Thread{
-		Print: func(_ *skylark.Thread, msg string) { fmt.Fprintln(p.Stdout, msg) },
+		Print: func(_ *skylark.Thread, msg string) {
+			fmt.Fprintln(p.Stdout, msg)
+		},
+		Load: p.load,
 	}
 
 	_, err := skylark.ExecFile(thread, file, nil, p.builtins())
@@ -54,6 +63,34 @@ func (p *Petsitter) run(t *skylark.Thread, fn *skylark.Builtin, args skylark.Tup
 	return skylark.None, nil
 }
 
+func (p *Petsitter) load(t *skylark.Thread, module string) (skylark.StringDict, error) {
+	url, err := url.Parse(module)
+	if err != nil {
+		return nil, err
+	}
+
+	switch url.Scheme {
+	case "go-get":
+		importPath := path.Join(url.Host, url.Path)
+		if fmt.Sprintf("go-get://%s", importPath) != module {
+			return nil, fmt.Errorf("go-get URLs may not contain query or fragment info")
+		}
+
+		// TODO(nick): Use the dir returned by LoadGoRepo to run PetsFile recursively
+		dir, err := loader.LoadGoRepo(importPath, build.Default)
+		if err != nil {
+			return nil, fmt.Errorf("load: %v", err)
+		}
+		dict := map[string]skylark.Value{}
+		dict["dir"] = skylark.String(dir)
+		return skylark.StringDict(dict), nil
+	case "":
+		return nil, fmt.Errorf("Loading files relative to %s not implemented", Petsfile)
+	default:
+		return nil, fmt.Errorf("Unknown load() strategy: %s. Available load schemes: go", url.Scheme)
+	}
+}
+
 func argToCmd(b *skylark.Builtin, argV skylark.Value) ([]string, error) {
 	switch argV := argV.(type) {
 	case skylark.String:
@@ -64,7 +101,6 @@ func argToCmd(b *skylark.Builtin, argV skylark.Value) ([]string, error) {
 }
 
 func GetFilePath() string {
-	const Petsfile = "Petsfile"
 	cwd, _ := os.Getwd()
 
 	return filepath.Join(cwd, Petsfile)

--- a/internal/mill/exec_test.go
+++ b/internal/mill/exec_test.go
@@ -55,6 +55,28 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestLoadGoGet(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	petsitter := &Petsitter{Stdout: stdout, Stderr: stderr}
+	dir, _ := ioutil.TempDir("", t.Name())
+	file := filepath.Join(dir, "Petsfile")
+	ioutil.WriteFile(file, []byte(`
+load("go-get://github.com/windmilleng/blorg-frontend", blorg_fe_dir="dir")
+print(blorg_fe_dir)
+`), os.FileMode(0777))
+	err := petsitter.ExecFile(file)
+	defer os.RemoveAll(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "github.com/windmilleng/blorg-frontend") {
+		t.Errorf("Expected import 'blorg-frontend'. Actual: %s", out)
+	}
+}
+
 func newTestPetsitter(t *testing.T) (*Petsitter, *bytes.Buffer) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}


### PR DESCRIPTION
Hello @yuindustries, @pmt,

Please review the following commits I made in branch nicks/service:

bbec9674023467df7e8ab17b33930954944c61d5 (2018-07-24 18:12:57 -0400)
mill: Add Petsfile hook for go-get

8fbeb68c51606de9b0114c43163994f4bf3dfc2d (2018-07-24 17:58:07 -0400)
Turn dry-run into a real flag (#17)
* Turn dry-run into a real flag

* Flags become persistent

7ac5ec73308fd47c84aaa7003d3727ec43e0daa5 (2018-07-24 15:23:55 -0400)
loader: Add a loader for Go repos