### PR TITLE
[VERY WIP]: pets: Skeleton for Service

### DIFF
--- a/cmd/pets/dry-run.go
+++ b/cmd/pets/dry-run.go
@@ -24,6 +24,7 @@ var DryRunCmd = &cobra.Command{
 			Stdout: os.Stdout,
 			Stderr: os.Stderr,
 			Runner: runner,
+			Procfs: procfs,
 		}
 		err = petsitter.ExecFile(file)
 		if err != nil {

--- a/internal/mill/exec.go
+++ b/internal/mill/exec.go
@@ -174,6 +174,7 @@ func (p *Petsitter) service(t *skylark.Thread, fn *skylark.Builtin, args skylark
 	var server skylark.Dict
 	var host string
 	var port int
+	var pid int
 
 	if err := skylark.UnpackArgs("service", args, kwargs, "server", &server, "host", &host, "port", &port); err != nil {
 		return nil, err
@@ -187,12 +188,16 @@ func (p *Petsitter) service(t *skylark.Thread, fn *skylark.Builtin, args skylark
 		}
 	}
 
-	// procs, err := proc.ProcFS.ProcsFromFS()
-	// for _, p := range procs {
-	// 	fmt.Printf("%d\t%s\n", p.Pid, p.DisplayName)
-	// }
+	// from the pid, get the process. then use that to modify the process.
+	procs, err := proc.ProcFS.ProcsFromFS()
+	for _, p := range procs {
+		// find when pid == proc
+		if p.Pid == pid {
+			pr := p.Pid
+		}
+	}
 
-	pid.ModifyProc(proc.PetsProc.WithExposedHost(host, port))
+	pr.ModifyProc(proc.PetsProc.WithExposedHost(host, port))
 
 	return skylark.None, nil
 }

--- a/internal/mill/exec.go
+++ b/internal/mill/exec.go
@@ -169,34 +169,31 @@ func (p *Petsitter) execPetsFileAt(t *skylark.Thread, module string, isMissingOk
 }
 
 // Service(server, “localhost”, 8081)
-func service(t *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func (p *Petsitter) service(t *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	// Are we starting a process (service?) or modifying one?
-
-	var server, localhost string
+	var server skylark.Dict
+	var host string
 	var port int
 
-	if err := skylark.UnpackArgs("service", args, kwargs, "server", &server, "localhost", &localhost, "port", &port); err != nil {
+	if err := skylark.UnpackArgs("service", args, kwargs, "server", &server, "host", &host, "port", &port); err != nil {
 		return nil, err
 	}
 
-	// service ... uses some procfs function?
+	// get pid from server as go object - get process of pid from procfs list (all in go)
+	for _, serverItem := range server.Items() {
+		key := serverItem[0]
+		if pid, found, _ := server.Get(key); !found {
+			return skylark.None, nil
+		}
+	}
 
-	// svcArgs, err := argToCmd(fn, service)
-	// if err != nil {
-	// 	return nil, err
+	// procs, err := proc.ProcFS.ProcsFromFS()
+	// for _, p := range procs {
+	// 	fmt.Printf("%d\t%s\n", p.Pid, p.DisplayName)
 	// }
 
-	// port := process.Proc.Port
-	// host := process.Proc.Hostname
+	pid.ModifyProc(proc.PetsProc.WithExposedHost(host, port))
 
-	// d := &skylark.Dict{}
-	// pt := skylark.String("port")
-	// ht := skylark.String("host")
-	// ptVal := skylark.MakeInt(port)
-	// htName := skylark.String(host)
-	// d.Set(pt, ptVal)
-	// d.Set(ht, htName)
-	// return d, nil
 	return skylark.None, nil
 }
 

--- a/internal/mill/exec.go
+++ b/internal/mill/exec.go
@@ -120,37 +120,36 @@ func (p *Petsitter) load(t *skylark.Thread, module string) (skylark.StringDict, 
 	}
 }
 
+// Service(server, “localhost”, 8081)
 func service(t *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	// Are we starting a process (service?) or modifying one?
-	var process proc.PetsCommand
-	var petsproc proc.PetsProc
 
-	var cmdV skylark.Value
+	var server, localhost string
+	var port int
 
-	if err := skylark.UnpackArgs("cmdV", args, kwargs,
-		"cmdV", &cmdV,
-	); err != nil {
+	if err := skylark.UnpackArgs("service", args, kwargs, "server", &server, "localhost", &localhost, "port", &port); err != nil {
 		return nil, err
 	}
 
-	cmdArgs, err := argToCmd(fn, cmdV)
-	if err != nil {
-		return nil, err
-	}
+	// service ... uses some procfs function?
 
-	port := process.Proc.Port
-	host := process.Proc.Hostname
+	// svcArgs, err := argToCmd(fn, service)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	serv := proc.PetsProc.WithExposedHost(petsproc, host, port) // don't know how to do err handling
+	// port := process.Proc.Port
+	// host := process.Proc.Hostname
 
-	d := &skylark.Dict{}
-	pt := skylark.String("port")
-	ht := skylark.String("host")
-	ptVal := skylark.MakeInt(port)
-	htName := skylark.String(host)
-	d.Set(pt, ptVal)
-	d.Set(ht, htName)
-	return d, nil
+	// d := &skylark.Dict{}
+	// pt := skylark.String("port")
+	// ht := skylark.String("host")
+	// ptVal := skylark.MakeInt(port)
+	// htName := skylark.String(host)
+	// d.Set(pt, ptVal)
+	// d.Set(ht, htName)
+	// return d, nil
+	return skylark.None, nil
 }
 
 func argToCmd(b *skylark.Builtin, argV skylark.Value) ([]string, error) {

--- a/internal/mill/exec.go
+++ b/internal/mill/exec.go
@@ -120,6 +120,39 @@ func (p *Petsitter) load(t *skylark.Thread, module string) (skylark.StringDict, 
 	}
 }
 
+func service(t *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	// Are we starting a process (service?) or modifying one?
+	var process proc.PetsCommand
+	var petsproc proc.PetsProc
+
+	var cmdV skylark.Value
+
+	if err := skylark.UnpackArgs("cmdV", args, kwargs,
+		"cmdV", &cmdV,
+	); err != nil {
+		return nil, err
+	}
+
+	cmdArgs, err := argToCmd(fn, cmdV)
+	if err != nil {
+		return nil, err
+	}
+
+	port := process.Proc.Port
+	host := process.Proc.Hostname
+
+	serv := proc.PetsProc.WithExposedHost(petsproc, host, port) // don't know how to do err handling
+
+	d := &skylark.Dict{}
+	pt := skylark.String("port")
+	ht := skylark.String("host")
+	ptVal := skylark.MakeInt(port)
+	htName := skylark.String(host)
+	d.Set(pt, ptVal)
+	d.Set(ht, htName)
+	return d, nil
+}
+
 func argToCmd(b *skylark.Builtin, argV skylark.Value) ([]string, error) {
 	switch argV := argV.(type) {
 	case skylark.String:


### PR DESCRIPTION
I have some questions.
I get really confused on argument calls on stuff like ProcsFromFS and WithExposedHost. A good example is
```
not enough arguments in call to method expression proc.ProcFS.ProcsFromFS
    have ()
    want (proc.ProcFS)
```

on L192. 

I have a similar problem with how to define things like `pr` on L196. I need to declare it outside the function (right?) as a PetsProc but I'm not sure how.