### PR TITLE
proc: add service keys to procfs

### DIFF
--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"syscall"
 	"time"
+
+	"github.com/windmilleng/pets/internal/service"
 )
 
 // Process state that we expect to be written to disk and queried.
@@ -23,6 +25,10 @@ type PetsProc struct {
 
 	// The port that the process is listening on (e.g., '8080')
 	Port int `json:",omitempty"`
+
+	// The name+tier of the service that this process exposes
+	ServiceName service.Name `json:",omitempty"`
+	ServiceTier service.Tier `json:",omitempty"`
 }
 
 // Creates a new PetsProc that we know is listening on the given host and port.
@@ -32,6 +38,16 @@ type PetsProc struct {
 func (p PetsProc) WithExposedHost(hostname string, port int) PetsProc {
 	p.Hostname = hostname
 	p.Port = port
+	return p
+}
+
+// Creates a new PetsProc that matches a service key.
+//
+// Calling this method automatically creates a copy because it's a struct method
+// rather than a pointer method.
+func (p PetsProc) WithServiceKey(key service.Key) PetsProc {
+	p.ServiceName = key.Name
+	p.ServiceTier = key.Tier
 	return p
 }
 

--- a/internal/proc/procfs_test.go
+++ b/internal/proc/procfs_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/windmilleng/pets/internal/service"
 	"github.com/windmilleng/wmclient/pkg/dirs"
 )
 
@@ -47,6 +48,24 @@ func TestProcFSHost(t *testing.T) {
 	procfs.ModifyProc(proc.WithExposedHost("localhost", 8080))
 
 	expected := `{"Pid":12345,"StartTime":"0001-01-01T00:00:00Z","Hostname":"localhost","Port":8080}
+`
+	f.assertProcFile(expected)
+}
+
+func TestProcFSKey(t *testing.T) {
+	f := newProcFixture(t)
+	defer f.tearDown()
+
+	procfs := f.newProcFS()
+	proc := PetsProc{Pid: 12345}
+	err := procfs.AddProc(proc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	procfs.ModifyProc(proc.WithServiceKey(service.NewKey("frontend", "local")))
+
+	expected := `{"Pid":12345,"StartTime":"0001-01-01T00:00:00Z","ServiceName":"frontend","ServiceTier":"local"}
 `
 	f.assertProcFile(expected)
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/procfs:

3fa8ec925d38e8410db0e7ef951d0aa2b7552d58 (2018-07-27 18:46:51 -0400)
proc: add service keys to procfs