### PR TITLE
pets: 'pets down' should kill the process group rather than just the process

### DIFF
--- a/cmd/pets/down.go
+++ b/cmd/pets/down.go
@@ -31,7 +31,12 @@ var DownCmd = &cobra.Command{
 
 		for _, p := range procs {
 			// TODO: Decide what to do in edge cases, when killing pets doesn't work
-			err := syscall.Kill(p.Pid, syscall.SIGINT)
+
+			// Pets starts all processes with a process group. -p.Pid is a posix trick
+			// to kill all processes in the group. This is helpful for things like 'go run'
+			// that spawn subprocesses, so that the subprocesses get killed too.
+			pgid := -p.Pid
+			err := syscall.Kill(pgid, syscall.SIGINT)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)


### PR DESCRIPTION
Hello @pmt, @nicks,

Please review the following commits I made in branch nicks/down:

070b818427354cfb14b0ec169debe6df646ac392 (2018-07-31 18:02:36 -0400)
pets: 'pets down' should kill the process group rather than just the process