### PR TITLE
Create display name, fix spacing

### DIFF
--- a/cmd/pets/list.go
+++ b/cmd/pets/list.go
@@ -28,9 +28,9 @@ var ListCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Process ID\tName\n")
+		fmt.Printf("%-20s%-20s\n", "Process ID", "Name")
 		for _, p := range procs {
-			fmt.Printf("%d\t%s\n", p.Pid, p.DisplayName)
+			fmt.Printf("%-20d%-20s\n", p.Pid, p.DisplayName)
 		}
 	},
 }

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -48,6 +48,7 @@ func (p PetsProc) WithExposedHost(hostname string, port int) PetsProc {
 func (p PetsProc) WithServiceKey(key service.Key) PetsProc {
 	p.ServiceName = key.Name
 	p.ServiceTier = key.Tier
+	p.DisplayName = string(p.ServiceName) + "-" + string(p.ServiceTier)
 	return p
 }
 

--- a/internal/proc/procfs_test.go
+++ b/internal/proc/procfs_test.go
@@ -83,7 +83,7 @@ func TestProcFSKey(t *testing.T) {
 
 	procfs.ModifyProc(proc.WithServiceKey(service.NewKey("frontend", "local")))
 
-	expected := `{"Pid":12345,"StartTime":"0001-01-01T00:00:00Z","ServiceName":"frontend","ServiceTier":"local"}
+	expected := `{"DisplayName":"frontend-local","Pid":12345,"StartTime":"0001-01-01T00:00:00Z","ServiceName":"frontend","ServiceTier":"local"}
 `
 	f.assertProcFile(expected)
 }


### PR DESCRIPTION
![screenshot from 2018-08-01 10-51-51](https://user-images.githubusercontent.com/4122993/43532498-3e1b86ca-9580-11e8-8b24-e81ba6db8e85.png)
Before ^

![screenshot from 2018-08-01 11-44-03](https://user-images.githubusercontent.com/4122993/43532502-42c92f1a-9580-11e8-8322-b9e0858ff677.png)
After! ^ 

pretty simple but i'll start working on more pets list niceness if this looks good in terms of naming.