### PR TITLE
Truncate to second, not minute

### DIFF
--- a/cmd/pets/list.go
+++ b/cmd/pets/list.go
@@ -29,7 +29,7 @@ var ListCmd = &cobra.Command{
 
 		fmt.Printf("%-30s%-30s\n", "Name", "Age")
 		for _, p := range procs {
-			el := timeDur(p.TimeSince().Truncate(time.Minute))
+			el := timeDur(p.TimeSince().Truncate(time.Second))
 			fmt.Printf("%-30s%-30s\n", p.DisplayName, el)
 		}
 	},


### PR DESCRIPTION
Really quick, rounds to second not minute. Oops!