### PR TITLE
pets up: add a --with flag for specifying override, like in the blog post

### DIFF
--- a/internal/school/school.go
+++ b/internal/school/school.go
@@ -47,8 +47,14 @@ func NewPetSchool(procfs proc.ProcFS) *PetSchool {
 	}
 }
 
-func (s *PetSchool) AddOverride(name service.Name, tier service.Tier) {
+func (s *PetSchool) AddOverride(name service.Name, tier service.Tier) error {
+	key := service.NewKey(name, tier)
+	_, hasProvider := s.providers[key]
+	if !hasProvider {
+		return fmt.Errorf("Could not find provider for service %q, tier %q", name, tier)
+	}
 	s.overrides[name] = tier
+	return nil
 }
 
 func (s *PetSchool) AddProvider(key service.Key, provider Provider, deps []service.Name, position string) error {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/with:

f9efaea950d51cdc811929738c35083e10f34f39 (2018-08-03 16:49:30 -0400)
pets up: add a --with flag for specifying override, like in the blog post