### PR TITLE
pets: expand symlinks in unit tests to fix for macos

### DIFF
--- a/internal/mill/exec_test.go
+++ b/internal/mill/exec_test.go
@@ -306,7 +306,13 @@ def inner_pwd():
 	}
 
 	out := stdout.String()
-	expected := fmt.Sprintf("%s\n%s/inner\n", f.dir, f.dir)
+
+	dir, err := filepath.EvalSymlinks(f.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := fmt.Sprintf("%s\n%s/inner\n", dir, dir)
 	if out != expected {
 		t.Errorf("Expected:\n%s\n\nActual:\n%s", expected, out)
 	}


### PR DESCRIPTION
I've tested this on Mac but not Linux.

On MacOS, I get errors like this:
```
exec_test.go:311: Expected:
		/var/folders/0t/c8t9m67j7qs4y021nl5_3_yr0000gp/T/TestLoadRelativeWorkingDirectory445595417
		/var/folders/0t/c8t9m67j7qs4y021nl5_3_yr0000gp/T/TestLoadRelativeWorkingDirectory445595417/inner
```

because:
```
$ ls -ld /tmp
lrwxr-xr-x@ 1 root  wheel  11 Mar 28 05:53 /tmp@ -> private/tmp
```